### PR TITLE
fix: remove wrapper box component

### DIFF
--- a/src/prefabs/pageWithGridView.js
+++ b/src/prefabs/pageWithGridView.js
@@ -4707,1080 +4707,719 @@
                     ],
                     descendants: [
                       {
-                        name: 'Box',
+                        name: 'Card',
                         options: [
                           {
-                            value: 'none',
-                            label: 'Alignment',
-                            key: 'alignment',
+                            label: 'Square',
+                            key: 'square',
+                            value: false,
+                            type: 'TOGGLE',
+                          },
+                          {
+                            label: 'Variant',
+                            key: 'variant',
+                            value: 'outlined',
                             type: 'CUSTOM',
                             configuration: {
                               as: 'BUTTONGROUP',
                               dataType: 'string',
                               allowedInput: [
-                                { name: 'None', value: 'none' },
-                                { name: 'Left', value: 'flex-start' },
-                                { name: 'Center', value: 'center' },
-                                { name: 'Right', value: 'flex-end' },
-                                { name: 'Justified', value: 'space-between' },
+                                { name: 'Elevation', value: 'elevation' },
+                                { name: 'Outlined', value: 'outlined' },
                               ],
                             },
                           },
                           {
-                            value: 'none',
-                            label: 'Vertical alignment',
-                            key: 'valignment',
-                            type: 'CUSTOM',
-                            configuration: {
-                              as: 'BUTTONGROUP',
-                              dataType: 'string',
-                              allowedInput: [
-                                { name: 'None', value: 'none' },
-                                { name: 'Top', value: 'flex-start' },
-                                { name: 'Center', value: 'center' },
-                                { name: 'Bottom', value: 'flex-end' },
-                              ],
-                            },
-                          },
-                          {
-                            value: false,
-                            label: 'Stretch (when in flex container)',
-                            key: 'stretch',
-                            type: 'TOGGLE',
-                          },
-                          {
-                            value: false,
-                            label: 'Transparent',
-                            key: 'transparent',
-                            type: 'TOGGLE',
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Height',
-                            key: 'height',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Width',
-                            key: 'width',
-                            value: '288px',
-                            configuration: {
-                              as: 'UNIT',
-                            },
-                          },
-                          {
-                            value: ['0rem', '0rem', '0rem', '0rem'],
-                            label: 'Outer space',
-                            key: 'outerSpacing',
-                            type: 'SIZES',
-                          },
-                          {
-                            value: ['0rem', '0rem', '0rem', '0rem'],
-                            label: 'Inner space',
-                            key: 'innerSpacing',
-                            type: 'SIZES',
-                          },
-                          {
-                            value: false,
-                            label: 'Show positioning options',
-                            key: 'positioningOptions',
-                            type: 'TOGGLE',
-                          },
-                          {
-                            value: 'static',
-                            label: 'Position',
-                            key: 'position',
-                            type: 'CUSTOM',
-                            configuration: {
-                              as: 'BUTTONGROUP',
-                              dataType: 'string',
-                              allowedInput: [
-                                { name: 'Static', value: 'static' },
-                                { name: 'Relative', value: 'relative' },
-                                { name: 'Absolute', value: 'absolute' },
-                                { name: 'Fixed', value: 'fixed' },
-                                { name: 'Sticky', value: 'sticky' },
-                              ],
-                              condition: {
-                                type: 'SHOW',
-                                option: 'positioningOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Top position',
-                            key: 'top',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'positioningOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Right position',
-                            key: 'right',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'positioningOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Bottom position',
-                            key: 'bottom',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'positioningOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Left position',
-                            key: 'left',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'positioningOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: false,
-                            label: 'Show background options',
-                            key: 'backgroundOptions',
-                            type: 'TOGGLE',
-                          },
-                          {
-                            value: 'Transparent',
-                            label: 'Background color',
-                            key: 'backgroundColor',
-                            type: 'COLOR',
-                            configuration: {
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 100,
-                            label: 'Background color opacity',
-                            key: 'backgroundColorAlpha',
-                            type: 'NUMBER',
-                            configuration: {
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: [''],
-                            label: 'Background url',
-                            key: 'backgroundUrl',
-                            type: 'VARIABLE',
-                            configuration: {
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 'initial',
-                            label: 'Background size',
-                            key: 'backgroundSize',
-                            type: 'CUSTOM',
-                            configuration: {
-                              as: 'BUTTONGROUP',
-                              dataType: 'string',
-                              allowedInput: [
-                                { name: 'Initial', value: 'initial' },
-                                { name: 'Contain', value: 'contain' },
-                                { name: 'Cover', value: 'cover' },
-                              ],
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 'center center',
-                            label: 'Background position',
-                            key: 'backgroundPosition',
+                            label: 'Elevation',
+                            key: 'elevation',
+                            value: '1',
                             type: 'CUSTOM',
                             configuration: {
                               as: 'DROPDOWN',
                               dataType: 'string',
                               allowedInput: [
-                                { name: 'Left top', value: 'left top' },
-                                { name: 'Left center', value: 'left center' },
-                                { name: 'Left bottom', value: 'left bottom' },
-                                { name: 'Center top', value: 'center top' },
-                                {
-                                  name: 'Center center',
-                                  value: 'center center',
-                                },
-                                {
-                                  name: 'Center bottom',
-                                  value: 'center bottom',
-                                },
-                                { name: 'Right top', value: 'right top' },
-                                { name: 'Right center', value: 'right center' },
-                                { name: 'Right bottom', value: 'right bottom' },
+                                { name: '1', value: '1' },
+                                { name: '2', value: '2' },
+                                { name: '3', value: '3' },
+                                { name: '4', value: '4' },
+                                { name: '5', value: '5' },
+                                { name: '6', value: '6' },
+                                { name: '7', value: '7' },
+                                { name: '8', value: '8' },
+                                { name: '9', value: '9' },
+                                { name: '10', value: '10' },
+                                { name: '11', value: '11' },
+                                { name: '12', value: '12' },
+                                { name: '13', value: '13' },
+                                { name: '14', value: '14' },
+                                { name: '15', value: '15' },
+                                { name: '16', value: '16' },
+                                { name: '17', value: '17' },
+                                { name: '18', value: '18' },
+                                { name: '19', value: '19' },
+                                { name: '20', value: '20' },
+                                { name: '21', value: '21' },
+                                { name: '22', value: '22' },
+                                { name: '23', value: '23' },
+                                { name: '24', value: '24' },
                               ],
                               condition: {
                                 type: 'SHOW',
-                                option: 'backgroundOptions',
+                                option: 'variant',
                                 comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 'no-repeat',
-                            label: 'Background repeat',
-                            key: 'backgroundRepeat',
-                            type: 'CUSTOM',
-                            configuration: {
-                              as: 'BUTTONGROUP',
-                              dataType: 'string',
-                              allowedInput: [
-                                { name: 'None', value: 'no-repeat' },
-                                { name: 'X', value: 'repeat-x' },
-                                { name: 'Y', value: 'repeat-y' },
-                                { name: 'All', value: 'repeat' },
-                              ],
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 'Transparent',
-                            label: 'Border color',
-                            key: 'borderColor',
-                            type: 'COLOR',
-                            configuration: {
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Border thickness',
-                            key: 'borderWidth',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            value: 'solid',
-                            label: 'Border style',
-                            key: 'borderStyle',
-                            type: 'CUSTOM',
-                            configuration: {
-                              as: 'BUTTONGROUP',
-                              dataType: 'string',
-                              allowedInput: [
-                                { name: 'None', value: 'none' },
-                                { name: 'Solid', value: 'solid' },
-                                { name: 'Dashed', value: 'dashed' },
-                                { name: 'Dotted', value: 'dotted' },
-                              ],
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
-                              },
-                            },
-                          },
-                          {
-                            type: 'SIZE',
-                            label: 'Border radius',
-                            key: 'borderRadius',
-                            value: '',
-                            configuration: {
-                              as: 'UNIT',
-                              condition: {
-                                type: 'SHOW',
-                                option: 'backgroundOptions',
-                                comparator: 'EQ',
-                                value: true,
+                                value: 'elevation',
                               },
                             },
                           },
                         ],
                         descendants: [
                           {
-                            name: 'Card',
+                            name: 'CardMedia',
                             options: [
                               {
-                                label: 'Square',
-                                key: 'square',
-                                value: false,
-                                type: 'TOGGLE',
-                              },
-                              {
-                                label: 'Variant',
-                                key: 'variant',
-                                value: 'outlined',
+                                label: 'Media type',
+                                key: 'type',
+                                value: 'img',
                                 type: 'CUSTOM',
                                 configuration: {
                                   as: 'BUTTONGROUP',
                                   dataType: 'string',
                                   allowedInput: [
-                                    { name: 'Elevation', value: 'elevation' },
-                                    { name: 'Outlined', value: 'outlined' },
+                                    { name: 'Image', value: 'img' },
+                                    { name: 'Video', value: 'video' },
+                                    { name: 'I-frame', value: 'iframe' },
                                   ],
                                 },
                               },
                               {
-                                label: 'Elevation',
-                                key: 'elevation',
-                                value: '1',
-                                type: 'CUSTOM',
+                                value: [
+                                  'https://material-ui.com/static/images/cards/contemplative-reptile.jpg',
+                                ],
+                                label: 'Source',
+                                key: 'imageSource',
+                                type: 'VARIABLE',
                                 configuration: {
-                                  as: 'DROPDOWN',
-                                  dataType: 'string',
-                                  allowedInput: [
-                                    { name: '1', value: '1' },
-                                    { name: '2', value: '2' },
-                                    { name: '3', value: '3' },
-                                    { name: '4', value: '4' },
-                                    { name: '5', value: '5' },
-                                    { name: '6', value: '6' },
-                                    { name: '7', value: '7' },
-                                    { name: '8', value: '8' },
-                                    { name: '9', value: '9' },
-                                    { name: '10', value: '10' },
-                                    { name: '11', value: '11' },
-                                    { name: '12', value: '12' },
-                                    { name: '13', value: '13' },
-                                    { name: '14', value: '14' },
-                                    { name: '15', value: '15' },
-                                    { name: '16', value: '16' },
-                                    { name: '17', value: '17' },
-                                    { name: '18', value: '18' },
-                                    { name: '19', value: '19' },
-                                    { name: '20', value: '20' },
-                                    { name: '21', value: '21' },
-                                    { name: '22', value: '22' },
-                                    { name: '23', value: '23' },
-                                    { name: '24', value: '24' },
-                                  ],
                                   condition: {
                                     type: 'SHOW',
-                                    option: 'variant',
+                                    option: 'type',
                                     comparator: 'EQ',
-                                    value: 'elevation',
+                                    value: 'img',
                                   },
                                 },
                               },
+                              {
+                                value: [],
+                                label: 'Source',
+                                key: 'videoSource',
+                                type: 'VARIABLE',
+                                configuration: {
+                                  condition: {
+                                    type: 'SHOW',
+                                    option: 'type',
+                                    comparator: 'EQ',
+                                    value: 'video',
+                                  },
+                                },
+                              },
+                              {
+                                value: [],
+                                label: 'Source',
+                                key: 'iframeSource',
+                                type: 'VARIABLE',
+                                configuration: {
+                                  condition: {
+                                    type: 'SHOW',
+                                    option: 'type',
+                                    comparator: 'EQ',
+                                    value: 'iframe',
+                                  },
+                                },
+                              },
+                              {
+                                value: [],
+                                label: 'Title',
+                                key: 'title',
+                                type: 'VARIABLE',
+                              },
                             ],
+                            descendants: [],
+                          },
+                          {
+                            name: 'CardHeader',
+                            options: [
+                              {
+                                value: [],
+                                label: 'Avatar',
+                                key: 'avatar',
+                                type: 'VARIABLE',
+                              },
+                              {
+                                label: 'Avatar type',
+                                key: 'avatarType',
+                                value: 'text',
+                                type: 'CUSTOM',
+                                configuration: {
+                                  as: 'BUTTONGROUP',
+                                  dataType: 'string',
+                                  allowedInput: [
+                                    { name: 'Text', value: 'text' },
+                                    { name: 'Image', value: 'image' },
+                                  ],
+                                  condition: {
+                                    type: 'HIDE',
+                                    option: 'avatar',
+                                    comparator: 'EQ',
+                                    value: '',
+                                  },
+                                },
+                              },
+                              {
+                                value: ['Title'],
+                                label: 'Title',
+                                key: 'title',
+                                type: 'VARIABLE',
+                              },
+                              {
+                                value: ['Subheader'],
+                                label: 'Sub header',
+                                key: 'subheader',
+                                type: 'VARIABLE',
+                              },
+                            ],
+                            descendants: [],
+                          },
+                          {
+                            name: 'CardContent',
+                            options: [],
                             descendants: [
                               {
-                                name: 'CardMedia',
+                                name: 'Text',
                                 options: [
                                   {
-                                    label: 'Media type',
+                                    type: 'VARIABLE',
+                                    label: 'Content',
+                                    key: 'content',
+                                    value: ['Description'],
+                                    configuration: {
+                                      as: 'MULTILINE',
+                                    },
+                                  },
+                                  {
+                                    type: 'TOGGLE',
+                                    label: 'Display Rich Text',
+                                    key: 'useInnerHtml',
+                                    value: false,
+                                  },
+                                  {
+                                    value: 'Body2',
+                                    label: 'Type',
                                     key: 'type',
-                                    value: 'img',
+                                    type: 'FONT',
+                                  },
+                                  {
                                     type: 'CUSTOM',
+                                    label: 'Text Alignment',
+                                    key: 'textAlignment',
+                                    value: 'left',
                                     configuration: {
                                       as: 'BUTTONGROUP',
                                       dataType: 'string',
                                       allowedInput: [
-                                        { name: 'Image', value: 'img' },
-                                        { name: 'Video', value: 'video' },
-                                        { name: 'I-frame', value: 'iframe' },
+                                        { name: 'Left', value: 'left' },
+                                        { name: 'Center', value: 'center' },
+                                        { name: 'Right', value: 'right' },
                                       ],
                                     },
                                   },
                                   {
-                                    value: [
-                                      'https://material-ui.com/static/images/cards/contemplative-reptile.jpg',
-                                    ],
-                                    label: 'Source',
-                                    key: 'imageSource',
-                                    type: 'VARIABLE',
+                                    value: ['0rem', '0rem', '0rem', '0rem'],
+                                    label: 'Outer space',
+                                    key: 'outerSpacing',
+                                    type: 'SIZES',
+                                  },
+                                  {
+                                    type: 'CUSTOM',
+                                    label: 'Link to',
+                                    key: 'linkType',
+                                    value: 'internal',
+                                    configuration: {
+                                      as: 'BUTTONGROUP',
+                                      dataType: 'string',
+                                      allowedInput: [
+                                        {
+                                          name: 'Internal page',
+                                          value: 'internal',
+                                        },
+                                        {
+                                          name: 'External page',
+                                          value: 'external',
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    value: '',
+                                    label: 'Page',
+                                    key: 'linkTo',
+                                    type: 'ENDPOINT',
                                     configuration: {
                                       condition: {
                                         type: 'SHOW',
-                                        option: 'type',
+                                        option: 'linkType',
                                         comparator: 'EQ',
-                                        value: 'img',
+                                        value: 'internal',
                                       },
                                     },
                                   },
                                   {
-                                    value: [],
-                                    label: 'Source',
-                                    key: 'videoSource',
+                                    value: [''],
+                                    label: 'URL',
+                                    key: 'linkToExternal',
                                     type: 'VARIABLE',
                                     configuration: {
+                                      placeholder:
+                                        'Starts with https:// or http://',
                                       condition: {
                                         type: 'SHOW',
-                                        option: 'type',
+                                        option: 'linkType',
                                         comparator: 'EQ',
-                                        value: 'video',
+                                        value: 'external',
                                       },
                                     },
                                   },
                                   {
-                                    value: [],
-                                    label: 'Source',
-                                    key: 'iframeSource',
-                                    type: 'VARIABLE',
+                                    value: false,
+                                    label: 'Styles',
+                                    key: 'styles',
+                                    type: 'TOGGLE',
+                                  },
+                                  {
+                                    type: 'COLOR',
+                                    label: 'Text color',
+                                    key: 'textColor',
+                                    value: 'Black',
                                     configuration: {
                                       condition: {
                                         type: 'SHOW',
-                                        option: 'type',
+                                        option: 'styles',
                                         comparator: 'EQ',
-                                        value: 'iframe',
+                                        value: true,
                                       },
                                     },
                                   },
                                   {
-                                    value: [],
-                                    label: 'Title',
-                                    key: 'title',
-                                    type: 'VARIABLE',
+                                    type: 'CUSTOM',
+                                    label: 'Font weight',
+                                    key: 'fontWeight',
+                                    value: '400',
+                                    configuration: {
+                                      as: 'DROPDOWN',
+                                      dataType: 'string',
+                                      allowedInput: [
+                                        { name: '100', value: '100' },
+                                        { name: '200', value: '200' },
+                                        { name: '300', value: '300' },
+                                        { name: '400', value: '400' },
+                                        { name: '500', value: '500' },
+                                        { name: '600', value: '600' },
+                                        { name: '700', value: '700' },
+                                        { name: '800', value: '800' },
+                                        { name: '900', value: '900' },
+                                      ],
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'styles',
+                                        comparator: 'EQ',
+                                        value: true,
+                                      },
+                                    },
                                   },
                                 ],
                                 descendants: [],
                               },
+                            ],
+                          },
+                          {
+                            name: 'CardActions',
+                            options: [
                               {
-                                name: 'CardHeader',
+                                type: 'CUSTOM',
+                                label: 'Alignment',
+                                key: 'alignment',
+                                value: 'flex-end',
+                                configuration: {
+                                  as: 'BUTTONGROUP',
+                                  dataType: 'string',
+                                  allowedInput: [
+                                    {
+                                      name: 'Start',
+                                      value: 'flex-start',
+                                    },
+                                    {
+                                      name: 'Center',
+                                      value: 'center',
+                                    },
+                                    {
+                                      name: 'End',
+                                      value: 'flex-end',
+                                    },
+                                  ],
+                                },
+                              },
+                              {
+                                type: 'TOGGLE',
+                                label: 'Disable spacing',
+                                key: 'disableSpacing',
+                                value: false,
+                              },
+                            ],
+                            descendants: [
+                              {
+                                name: 'Button',
                                 options: [
                                   {
-                                    value: [],
-                                    label: 'Avatar',
-                                    key: 'avatar',
-                                    type: 'VARIABLE',
+                                    label: 'Toggle visibility',
+                                    key: 'visible',
+                                    value: true,
+                                    type: 'TOGGLE',
+                                    configuration: {
+                                      as: 'VISIBILITY',
+                                    },
                                   },
                                   {
-                                    label: 'Avatar type',
-                                    key: 'avatarType',
-                                    value: 'text',
                                     type: 'CUSTOM',
+                                    label: 'variant',
+                                    key: 'variant',
+                                    value: 'icon',
                                     configuration: {
                                       as: 'BUTTONGROUP',
                                       dataType: 'string',
                                       allowedInput: [
                                         { name: 'Text', value: 'text' },
-                                        { name: 'Image', value: 'image' },
+                                        {
+                                          name: 'Outlined',
+                                          value: 'outlined',
+                                        },
+                                        {
+                                          name: 'Contain',
+                                          value: 'contained',
+                                        },
+                                        { name: 'Icon', value: 'icon' },
                                       ],
+                                    },
+                                  },
+                                  {
+                                    type: 'VARIABLE',
+                                    label: 'Button text',
+                                    key: 'buttonText',
+                                    value: ['Button'],
+                                    configuration: {
                                       condition: {
                                         type: 'HIDE',
-                                        option: 'avatar',
+                                        option: 'variant',
                                         comparator: 'EQ',
-                                        value: '',
+                                        value: 'icon',
                                       },
                                     },
                                   },
                                   {
-                                    value: ['Title'],
-                                    label: 'Title',
-                                    key: 'title',
-                                    type: 'VARIABLE',
-                                  },
-                                  {
-                                    value: ['Subheader'],
-                                    label: 'Sub header',
-                                    key: 'subheader',
-                                    type: 'VARIABLE',
-                                  },
-                                ],
-                                descendants: [],
-                              },
-                              {
-                                name: 'CardContent',
-                                options: [],
-                                descendants: [
-                                  {
-                                    name: 'Text',
-                                    options: [
-                                      {
-                                        type: 'VARIABLE',
-                                        label: 'Content',
-                                        key: 'content',
-                                        value: ['Description'],
-                                        configuration: {
-                                          as: 'MULTILINE',
-                                        },
-                                      },
-                                      {
-                                        type: 'TOGGLE',
-                                        label: 'Display Rich Text',
-                                        key: 'useInnerHtml',
-                                        value: false,
-                                      },
-                                      {
-                                        value: 'Body2',
-                                        label: 'Type',
-                                        key: 'type',
-                                        type: 'FONT',
-                                      },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'Text Alignment',
-                                        key: 'textAlignment',
-                                        value: 'left',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            { name: 'Left', value: 'left' },
-                                            { name: 'Center', value: 'center' },
-                                            { name: 'Right', value: 'right' },
-                                          ],
-                                        },
-                                      },
-                                      {
-                                        value: ['0rem', '0rem', '0rem', '0rem'],
-                                        label: 'Outer space',
-                                        key: 'outerSpacing',
-                                        type: 'SIZES',
-                                      },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'Link to',
-                                        key: 'linkType',
-                                        value: 'internal',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            {
-                                              name: 'Internal page',
-                                              value: 'internal',
-                                            },
-                                            {
-                                              name: 'External page',
-                                              value: 'external',
-                                            },
-                                          ],
-                                        },
-                                      },
-                                      {
-                                        value: '',
-                                        label: 'Page',
-                                        key: 'linkTo',
-                                        type: 'ENDPOINT',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'internal',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: [''],
-                                        label: 'URL',
-                                        key: 'linkToExternal',
-                                        type: 'VARIABLE',
-                                        configuration: {
-                                          placeholder:
-                                            'Starts with https:// or http://',
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'external',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: false,
-                                        label: 'Styles',
-                                        key: 'styles',
-                                        type: 'TOGGLE',
-                                      },
-                                      {
-                                        type: 'COLOR',
-                                        label: 'Text color',
-                                        key: 'textColor',
-                                        value: 'Black',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'styles',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
-                                        },
-                                      },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'Font weight',
-                                        key: 'fontWeight',
-                                        value: '400',
-                                        configuration: {
-                                          as: 'DROPDOWN',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            { name: '100', value: '100' },
-                                            { name: '200', value: '200' },
-                                            { name: '300', value: '300' },
-                                            { name: '400', value: '400' },
-                                            { name: '500', value: '500' },
-                                            { name: '600', value: '600' },
-                                            { name: '700', value: '700' },
-                                            { name: '800', value: '800' },
-                                            { name: '900', value: '900' },
-                                          ],
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'styles',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
-                                        },
-                                      },
-                                    ],
-                                    descendants: [],
-                                  },
-                                ],
-                              },
-                              {
-                                name: 'CardActions',
-                                options: [
-                                  {
                                     type: 'CUSTOM',
-                                    label: 'Alignment',
-                                    key: 'alignment',
-                                    value: 'flex-end',
+                                    label: 'Link to',
+                                    key: 'linkType',
+                                    value: 'internal',
                                     configuration: {
                                       as: 'BUTTONGROUP',
                                       dataType: 'string',
                                       allowedInput: [
                                         {
-                                          name: 'Start',
-                                          value: 'flex-start',
+                                          name: 'Internal page',
+                                          value: 'internal',
                                         },
                                         {
-                                          name: 'Center',
-                                          value: 'center',
+                                          name: 'External page',
+                                          value: 'external',
+                                        },
+                                        { name: 'Action', value: 'action' },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    value: '',
+                                    label: 'Page',
+                                    key: 'linkTo',
+                                    type: 'ENDPOINT',
+                                    configuration: {
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'linkType',
+                                        comparator: 'EQ',
+                                        value: 'internal',
+                                      },
+                                    },
+                                  },
+                                  {
+                                    value: [''],
+                                    label: 'URL',
+                                    key: 'linkToExternal',
+                                    type: 'VARIABLE',
+                                    configuration: {
+                                      placeholder:
+                                        'Starts with https:// or http://',
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'linkType',
+                                        comparator: 'EQ',
+                                        value: 'external',
+                                      },
+                                    },
+                                  },
+                                  {
+                                    value: '_self',
+                                    label: 'Open in',
+                                    key: 'openLinkToExternal',
+                                    type: 'CUSTOM',
+                                    configuration: {
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'linkType',
+                                        comparator: 'EQ',
+                                        value: 'external',
+                                      },
+                                      as: 'BUTTONGROUP',
+                                      dataType: 'string',
+                                      allowedInput: [
+                                        {
+                                          name: 'Current Tab',
+                                          value: '_self',
                                         },
                                         {
-                                          name: 'End',
-                                          value: 'flex-end',
+                                          name: 'New Tab',
+                                          value: '_blank',
                                         },
                                       ],
                                     },
                                   },
                                   {
-                                    type: 'TOGGLE',
-                                    label: 'Disable spacing',
-                                    key: 'disableSpacing',
-                                    value: false,
+                                    value: '',
+                                    label: 'Action',
+                                    key: 'actionId',
+                                    type: 'ACTION',
+                                    configuration: {
+                                      apiVersion: 'v1',
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'linkType',
+                                        comparator: 'EQ',
+                                        value: 'action',
+                                      },
+                                    },
                                   },
-                                ],
-                                descendants: [
                                   {
-                                    name: 'Button',
-                                    options: [
-                                      {
-                                        label: 'Toggle visibility',
-                                        key: 'visible',
-                                        value: true,
-                                        type: 'TOGGLE',
-                                        configuration: {
-                                          as: 'VISIBILITY',
-                                        },
-                                      },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'variant',
-                                        key: 'variant',
+                                    value: false,
+                                    label: 'Full width',
+                                    key: 'fullWidth',
+                                    type: 'TOGGLE',
+                                    configuration: {
+                                      condition: {
+                                        type: 'HIDE',
+                                        option: 'variant',
+                                        comparator: 'EQ',
                                         value: 'icon',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            { name: 'Text', value: 'text' },
-                                            {
-                                              name: 'Outlined',
-                                              value: 'outlined',
-                                            },
-                                            {
-                                              name: 'Contain',
-                                              value: 'contained',
-                                            },
-                                            { name: 'Icon', value: 'icon' },
-                                          ],
-                                        },
                                       },
-                                      {
-                                        type: 'VARIABLE',
-                                        label: 'Button text',
-                                        key: 'buttonText',
-                                        value: ['Button'],
-                                        configuration: {
-                                          condition: {
-                                            type: 'HIDE',
-                                            option: 'variant',
-                                            comparator: 'EQ',
-                                            value: 'icon',
-                                          },
-                                        },
+                                    },
+                                  },
+                                  {
+                                    value: 'medium',
+                                    label: 'Size',
+                                    key: 'size',
+                                    type: 'CUSTOM',
+                                    configuration: {
+                                      as: 'BUTTONGROUP',
+                                      dataType: 'string',
+                                      allowedInput: [
+                                        { name: 'Large', value: 'large' },
+                                        { name: 'Medium', value: 'medium' },
+                                        { name: 'Small', value: 'small' },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    label: 'Icon',
+                                    key: 'icon',
+                                    value: 'ChevronRight',
+                                    type: 'CUSTOM',
+                                    configuration: iconConfiguration,
+                                  },
+                                  {
+                                    type: 'CUSTOM',
+                                    label: 'Icon position',
+                                    key: 'iconPosition',
+                                    value: 'start',
+                                    configuration: {
+                                      as: 'BUTTONGROUP',
+                                      dataType: 'string',
+                                      condition: {
+                                        type: 'HIDE',
+                                        option: 'variant',
+                                        comparator: 'EQ',
+                                        value: 'icon',
                                       },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'Link to',
-                                        key: 'linkType',
-                                        value: 'internal',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            {
-                                              name: 'Internal page',
-                                              value: 'internal',
-                                            },
-                                            {
-                                              name: 'External page',
-                                              value: 'external',
-                                            },
-                                            { name: 'Action', value: 'action' },
-                                          ],
-                                        },
+                                      allowedInput: [
+                                        { name: 'Start', value: 'start' },
+                                        { name: 'End', value: 'end' },
+                                      ],
+                                    },
+                                  },
+                                  {
+                                    type: 'COLOR',
+                                    label: 'Text color',
+                                    key: 'textColor',
+                                    value: 'Primary',
+                                    configuration: {
+                                      condition: {
+                                        type: 'HIDE',
+                                        option: 'variant',
+                                        comparator: 'EQ',
+                                        value: 'icon',
                                       },
-                                      {
-                                        value: '',
-                                        label: 'Page',
-                                        key: 'linkTo',
-                                        type: 'ENDPOINT',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'internal',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: [''],
-                                        label: 'URL',
-                                        key: 'linkToExternal',
-                                        type: 'VARIABLE',
-                                        configuration: {
-                                          placeholder:
-                                            'Starts with https:// or http://',
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'external',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: '_self',
-                                        label: 'Open in',
-                                        key: 'openLinkToExternal',
-                                        type: 'CUSTOM',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'external',
-                                          },
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            {
-                                              name: 'Current Tab',
-                                              value: '_self',
-                                            },
-                                            {
-                                              name: 'New Tab',
-                                              value: '_blank',
-                                            },
-                                          ],
-                                        },
-                                      },
-                                      {
-                                        value: '',
-                                        label: 'Action',
-                                        key: 'actionId',
-                                        type: 'ACTION',
-                                        configuration: {
-                                          apiVersion: 'v1',
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'linkType',
-                                            comparator: 'EQ',
-                                            value: 'action',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: false,
-                                        label: 'Full width',
-                                        key: 'fullWidth',
-                                        type: 'TOGGLE',
-                                        configuration: {
-                                          condition: {
-                                            type: 'HIDE',
-                                            option: 'variant',
-                                            comparator: 'EQ',
-                                            value: 'icon',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        value: 'medium',
-                                        label: 'Size',
-                                        key: 'size',
-                                        type: 'CUSTOM',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            { name: 'Large', value: 'large' },
-                                            { name: 'Medium', value: 'medium' },
-                                            { name: 'Small', value: 'small' },
-                                          ],
-                                        },
-                                      },
-                                      {
-                                        label: 'Icon',
-                                        key: 'icon',
-                                        value: 'ChevronRight',
-                                        type: 'CUSTOM',
-                                        configuration: iconConfiguration,
-                                      },
-                                      {
-                                        type: 'CUSTOM',
-                                        label: 'Icon position',
-                                        key: 'iconPosition',
-                                        value: 'start',
-                                        configuration: {
-                                          as: 'BUTTONGROUP',
-                                          dataType: 'string',
-                                          condition: {
-                                            type: 'HIDE',
-                                            option: 'variant',
-                                            comparator: 'EQ',
-                                            value: 'icon',
-                                          },
-                                          allowedInput: [
-                                            { name: 'Start', value: 'start' },
-                                            { name: 'End', value: 'end' },
-                                          ],
-                                        },
-                                      },
-                                      {
-                                        type: 'COLOR',
-                                        label: 'Text color',
-                                        key: 'textColor',
-                                        value: 'Primary',
-                                        configuration: {
-                                          condition: {
-                                            type: 'HIDE',
-                                            option: 'variant',
-                                            comparator: 'EQ',
-                                            value: 'icon',
-                                          },
-                                        },
-                                      },
-                                      {
-                                        type: 'COLOR',
-                                        label: 'Color',
-                                        key: 'background',
-                                        value: 'Primary',
-                                      },
-                                      {
-                                        value: ['0rem', '0rem', '0rem', '0rem'],
-                                        label: 'Outer space',
-                                        key: 'outerSpacing',
-                                        type: 'SIZES',
-                                      },
-                                      {
-                                        label: 'Disabled',
-                                        key: 'disabled',
-                                        value: false,
-                                        type: 'TOGGLE',
-                                      },
-                                      {
-                                        label: 'Add Tooltip',
-                                        key: 'addTooltip',
-                                        value: false,
-                                        type: 'TOGGLE',
-                                        configuration: {
-                                          as: 'VISIBILITY',
-                                        },
-                                      },
-                                      {
-                                        label: 'Toggle tooltip visibility',
-                                        key: 'visibleTooltip',
+                                    },
+                                  },
+                                  {
+                                    type: 'COLOR',
+                                    label: 'Color',
+                                    key: 'background',
+                                    value: 'Primary',
+                                  },
+                                  {
+                                    value: ['0rem', '0rem', '0rem', '0rem'],
+                                    label: 'Outer space',
+                                    key: 'outerSpacing',
+                                    type: 'SIZES',
+                                  },
+                                  {
+                                    label: 'Disabled',
+                                    key: 'disabled',
+                                    value: false,
+                                    type: 'TOGGLE',
+                                  },
+                                  {
+                                    label: 'Add Tooltip',
+                                    key: 'addTooltip',
+                                    value: false,
+                                    type: 'TOGGLE',
+                                    configuration: {
+                                      as: 'VISIBILITY',
+                                    },
+                                  },
+                                  {
+                                    label: 'Toggle tooltip visibility',
+                                    key: 'visibleTooltip',
+                                    value: true,
+                                    type: 'TOGGLE',
+                                    configuration: {
+                                      as: 'VISIBILITY',
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'addTooltip',
+                                        comparator: 'EQ',
                                         value: true,
-                                        type: 'TOGGLE',
-                                        configuration: {
-                                          as: 'VISIBILITY',
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'addTooltip',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
-                                        },
                                       },
-                                      {
-                                        type: 'VARIABLE',
-                                        label: 'Tooltip Content',
-                                        key: 'tooltipContent',
-                                        value: ['Tips'],
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'addTooltip',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
-                                        },
+                                    },
+                                  },
+                                  {
+                                    type: 'VARIABLE',
+                                    label: 'Tooltip Content',
+                                    key: 'tooltipContent',
+                                    value: ['Tips'],
+                                    configuration: {
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'addTooltip',
+                                        comparator: 'EQ',
+                                        value: true,
                                       },
-                                      {
-                                        label: 'Tooltip Placement',
-                                        key: 'tooltipPlacement',
-                                        value: 'bottom',
-                                        type: 'CUSTOM',
-                                        configuration: {
-                                          as: 'DROPDOWN',
-                                          dataType: 'string',
-                                          allowedInput: [
-                                            {
-                                              name: 'Top Start',
-                                              value: 'top-start',
-                                            },
-                                            {
-                                              name: 'Top',
-                                              value: 'top',
-                                            },
-                                            {
-                                              name: 'Top End',
-                                              value: 'top-end',
-                                            },
-                                            {
-                                              name: 'Right',
-                                              value: 'right',
-                                            },
-                                            {
-                                              name: 'Left',
-                                              value: 'left',
-                                            },
-                                            {
-                                              name: 'Botttom Start',
-                                              value: 'bottom-start',
-                                            },
-                                            {
-                                              name: 'Bottom',
-                                              value: 'bottom',
-                                            },
-                                            {
-                                              name: 'Bottom End',
-                                              value: 'bottom-end',
-                                            },
-                                          ],
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'addTooltip',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
+                                    },
+                                  },
+                                  {
+                                    label: 'Tooltip Placement',
+                                    key: 'tooltipPlacement',
+                                    value: 'bottom',
+                                    type: 'CUSTOM',
+                                    configuration: {
+                                      as: 'DROPDOWN',
+                                      dataType: 'string',
+                                      allowedInput: [
+                                        {
+                                          name: 'Top Start',
+                                          value: 'top-start',
                                         },
-                                      },
-                                      {
-                                        type: 'COLOR',
-                                        label: 'Tooltip Background',
-                                        key: 'tooltipBackground',
-                                        value: 'Medium',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'addTooltip',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
+                                        {
+                                          name: 'Top',
+                                          value: 'top',
                                         },
-                                      },
-                                      {
-                                        type: 'COLOR',
-                                        label: 'Tooltip Text',
-                                        key: 'tooltipText',
-                                        value: 'Black',
-                                        configuration: {
-                                          condition: {
-                                            type: 'SHOW',
-                                            option: 'addTooltip',
-                                            comparator: 'EQ',
-                                            value: true,
-                                          },
+                                        {
+                                          name: 'Top End',
+                                          value: 'top-end',
                                         },
+                                        {
+                                          name: 'Right',
+                                          value: 'right',
+                                        },
+                                        {
+                                          name: 'Left',
+                                          value: 'left',
+                                        },
+                                        {
+                                          name: 'Botttom Start',
+                                          value: 'bottom-start',
+                                        },
+                                        {
+                                          name: 'Bottom',
+                                          value: 'bottom',
+                                        },
+                                        {
+                                          name: 'Bottom End',
+                                          value: 'bottom-end',
+                                        },
+                                      ],
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'addTooltip',
+                                        comparator: 'EQ',
+                                        value: true,
                                       },
-                                    ],
-                                    descendants: [],
+                                    },
+                                  },
+                                  {
+                                    type: 'COLOR',
+                                    label: 'Tooltip Background',
+                                    key: 'tooltipBackground',
+                                    value: 'Medium',
+                                    configuration: {
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'addTooltip',
+                                        comparator: 'EQ',
+                                        value: true,
+                                      },
+                                    },
+                                  },
+                                  {
+                                    type: 'COLOR',
+                                    label: 'Tooltip Text',
+                                    key: 'tooltipText',
+                                    value: 'Black',
+                                    configuration: {
+                                      condition: {
+                                        type: 'SHOW',
+                                        option: 'addTooltip',
+                                        comparator: 'EQ',
+                                        value: true,
+                                      },
+                                    },
                                   },
                                 ],
+                                descendants: [],
                               },
                             ],
                           },
@@ -5833,6 +5472,9 @@
                 />
               </Field>
               <Field label="Title property">
+                <Text size="small" color="grey700" as="div">
+                  This property is also being used as search property.
+                </Text>
                 <PropertySelector
                   modelId={modelId}
                   onChange={value => {
@@ -5957,22 +5599,22 @@
                 prefabStructure[1].descendants[0].descendants[0].descendants[3];
               dataGrid.options[0].value = modelId;
               if (imageProperty.id) {
-                dataGrid.descendants[0].descendants[0].descendants[0].options[1].value = [
+                dataGrid.descendants[0].descendants[0].options[1].value = [
                   enrichVarObj(imageProperty),
                 ];
               }
               if (titleProperty.id) {
-                dataGrid.descendants[0].descendants[0].descendants[1].options[2].value = [
+                dataGrid.descendants[0].descendants[1].options[2].value = [
                   enrichVarObj(titleProperty),
                 ];
               }
               if (subheaderProperty.id) {
-                dataGrid.descendants[0].descendants[0].descendants[1].options[3].value = [
+                dataGrid.descendants[0].descendants[1].options[3].value = [
                   enrichVarObj(subheaderProperty),
                 ];
               }
               if (descriptionProperty.id) {
-                dataGrid.descendants[0].descendants[0].descendants[2].descendants[0].options[0].value = [
+                dataGrid.descendants[0].descendants[2].descendants[0].options[0].value = [
                   enrichVarObj(descriptionProperty),
                 ];
               }

--- a/src/prefabs/pageWithGridView.js
+++ b/src/prefabs/pageWithGridView.js
@@ -1,8 +1,8 @@
 (() => ({
-  name: 'Page with grid view',
+  name: 'Page With Grid View',
   icon: 'GridIcon',
   // type: 'page',
-  description: 'Page with grid view',
+  description: 'This is a page containing a data grid with a custom search field',
   category: 'LAYOUT',
   beforeCreate: ({
     helpers: { useModelQuery },

--- a/src/prefabs/pageWithGridView.js
+++ b/src/prefabs/pageWithGridView.js
@@ -2,7 +2,8 @@
   name: 'Page With Grid View',
   icon: 'GridIcon',
   // type: 'page',
-  description: 'This is a page containing a data grid with a custom search field',
+  description:
+    'This is a page containing a data grid with a custom search field',
   category: 'LAYOUT',
   beforeCreate: ({
     helpers: { useModelQuery },


### PR DESCRIPTION
The box component used as wrapper doesn't fix the styling problem (when having one record it's stretched out full-width). Instead, we need to change the CSS of the datalist component itself. Also, I've added a small info text in the beforeCreate modal saying that the title property is also used as search property.